### PR TITLE
Add ability to run traceflow as a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.7
+
+RUN mkdir -p /traceflow/vars
+
+WORKDIR /traceflow/
+
+ADD README.md .
+ADD setup.py .
+ADD requirements.txt .
+ADD traceflow /traceflow/traceflow
+ADD vars /traceflow/vars
+ADD docker/entrypoint.sh .
+
+RUN pip install -r requirements.txt
+
+RUN python setup.py bdist_wheel
+RUN pip install dist/traceflow*any.whl
+
+EXPOSE 8081/tcp
+
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ python3 setup.py bdist_wheel
 pip install ./dist/traceflow*any.whl
 ```
 
-
 ## Usage
 
 Usage should be designed to be as straight forward as possible. There are currently 3 output formats supported - Vertical Output (`--format=vert`), Horizontal output(`--format=horiz`) and experimental Vis.js/Browser based output(`--format=viz`). 
@@ -58,6 +57,20 @@ An example of vis.js outputs is as follows:
 
 More detailed help available in  `--help`.
 
+## Docker
+
+`traceflow` can also be ran as a Docker container:
+```
+$ docker build -t traceflow .
+$ docker run -i -t traceflow www.telia.se
+```
+
+To host the vis.js output through Docker:
+```
+$ docker run -p 127.0.0.1:8081:8081 -i -t traceflow --format=viz --bind=0.0.0.0 www.telia.se
+```
+
+Note that it is required to bind the web server to the address of a public interface (inside the container) to be able to reach the web page.
 
 ## Why 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+traceflow "$@"

--- a/traceflow/__main__.py
+++ b/traceflow/__main__.py
@@ -76,8 +76,14 @@ def get_help() -> argparse:
     )
     parser.add_argument(
         "--format",
-        help="Print the results vertically(--format=vert) or horizontally(--format=horiz)",
+        help="Print the results vertically (--format=vert) or horizontally (--format=horiz), or even represented in a web browser (--format=viz)",
         default="vert",
+        type=str,
+    )
+    parser.add_argument(
+        "--bind",
+        help="IP address to bind the vis.js web server to",
+        default="127.0.0.1",
         type=str,
     )
     parser.add_argument("--debug", help="Enable Debug Logging", action="store_true")
@@ -109,6 +115,7 @@ def main():
     DST_PORT = args.dstport
     SRC_PORT = args.srcport
     MAX_TTL = args.ttl
+    BIND_IP = args.bind
 
     if args.debug:
         logger = logging.getLogger()
@@ -196,7 +203,7 @@ def main():
         traceflow.printer.print_horizontal(traces)
     if args.format.lower() == "viz":
         # Experimental vis.js / browser based visualisation
-        traceflow.printer.start_viz(traces)
+        traceflow.printer.start_viz(traces, BIND_IP)
     exit(0)
 
 

--- a/traceflow/printer.py
+++ b/traceflow/printer.py
@@ -51,13 +51,12 @@ class printer:
         return None
 
     @staticmethod
-    def start_viz(traces) -> None:
+    def start_viz(traces, bind_ip) -> None:
         ## TODO: Break apart into different classes?
         # TODO: Need to re-home the http server to serve out of a tmp directory, or serve from
         import http.server
 
         port = 8081
-        bind_ip = "127.0.0.1"
         DIRECTORY = "vars/"
 
         class Handler(http.server.SimpleHTTPRequestHandler):


### PR DESCRIPTION
To avoid having to build the package from scratch on different systems or care about virtualenvs, it is nice to be able to use a Docker container and simply run traceflow directly. To be able to do this and still maintain vis.js functionality, an option to specify the bind_ip was needed. I won't be uploading an image to Docker Hub, for example. That can be done in an "official" way if you would want to.