### PR TITLE
Refactoring work for packet class. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   - python setup.py bdist_wheel
   - pip install ./dist/traceflow*any.whl
-  - black --check traceflow
+  - black --diff --verbose traceflow
   - black --check tests
   - sudo -E $(which pytest)
   - sudo -E $(which traceflow) 1.1.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   - python setup.py bdist_wheel
   - pip install ./dist/traceflow*any.whl
-  - black --diff --verbose traceflow
+  - black --check --diff --verbose traceflow
   - black --check tests
   - sudo -E $(which pytest)
   - sudo -E $(which traceflow) 1.1.1.1

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -122,17 +122,17 @@ class TestPacketEncode(unittest.TestCase):
         udp_src_port = self.test_encode_class_instance.udp_packet[0:2]
         self.assertEqual(udp_src_port, struct.pack("!H", 35000))
 
-    # UDP Packet Length: 18, computed.
-    def test_encode_udp_len(self):
-        # Len is 3rd word
-        udp_len = self.test_encode_class_instance.udp_packet[4:6]
-        self.assertEqual(udp_len, struct.pack("!H", 18))
-
     # udp_dst_port = 53
     def test_encode_udp_dst(self):
         # dst is 2nd word
         udp_dst_port = self.test_encode_class_instance.udp_packet[2:4]
         self.assertEqual(udp_dst_port, struct.pack("!H", 53))
+
+    # UDP Packet Length: 18, computed.
+    def test_encode_udp_len(self):
+        # Len is 3rd word
+        udp_len = self.test_encode_class_instance.udp_packet[4:6]
+        self.assertEqual(udp_len, struct.pack("!H", 18))
 
 
 if __name__ == "__main__":

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -122,17 +122,17 @@ class TestPacketEncode(unittest.TestCase):
         udp_src_port = self.test_encode_class_instance.udp_packet[0:2]
         self.assertEqual(udp_src_port, struct.pack("!H", 35000))
 
-    # udp_dst_port = 53
-    def test_encode_udp_dst(self):
-        # dst is 2nd word
-        udp_dst_port = self.test_encode_class_instance.udp_packet[2:4]
-        self.assertEqual(udp_dst_port, struct.pack("!H", 53))
-
     # UDP Packet Length: 18, computed.
     def test_encode_udp_len(self):
         # Len is 3rd word
         udp_len = self.test_encode_class_instance.udp_packet[4:6]
         self.assertEqual(udp_len, struct.pack("!H", 18))
+
+    # udp_dst_port = 53
+    def test_encode_udp_dst(self):
+        # dst is 2nd word
+        udp_dst_port = self.test_encode_class_instance.udp_packet[2:4]
+        self.assertEqual(udp_dst_port, struct.pack("!H", 53))
 
 
 if __name__ == "__main__":

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -84,61 +84,54 @@ class TestPacketEncode(unittest.TestCase):
 
     # IPv4 Tests here
     def test_decode_ipv4(self):
-        ipv4_hdr = self.test_encode_class_instance.encode_ipv4_header()
+        ipv4_hdr = self.test_encode_class_instance.ipv4_packet
         self.assertIsInstance(ipv4_hdr, bytes)
 
     # ttl = 3
     def test_encode_ipv4_ttl(self):
         # TTL is 9th byte
-        ttl = self.test_encode_class_instance.encode_ipv4_header()[8]
+        ttl = self.test_encode_class_instance.ipv4_packet[8]
         self.assertEqual(ttl, 3)
 
     # l4_proto = 17
     def test_encode_ipv4_l4_proto(self):
         # Proto is 9th byte
-        l4_proto = self.test_encode_class_instance.encode_ipv4_header()[9]
+        l4_proto = self.test_encode_class_instance.ipv4_packet[9]
         self.assertEqual(l4_proto, 17)
 
-    # Checksum is 9059 - pre-computed.
-    # def test_encode_ipv4_l4_proto_fixed_checksum(self):
-    # Checksum is 10th and 11th bytes
-    # l4_proto = self.test_encode_class_instance.encode_ipv4_header()[10:12]
-    # self.assertEqual(l4_proto, struct.pack("H", 9059))
-
-    # ip_saddr = traceflow.socket_handler.get_egress_ip(ip_daddr)
-    # This was pre-computed to 192.168.0.31 for this packet.
-    # def test_encode_ipv4_l4_proto_local_ip(self):
-    #     # Checksum is 10th and 11th bytes
-    #     ip_saddr = self.test_encode_class_instance.encode_ipv4_header()[12:16]
-    #     self.assertEqual(ip_saddr, socket.inet_aton("192.168.0.31"))
+    # This will always fail as the checksum is dynamic. Instead we're going to test for a 0 return
+    def test_encode_ipv4_l4_proto_fixed_checksum(self):
+        # Checksum is 10th and 11th bytes
+        l4_proto = self.test_encode_class_instance.ipv4_packet[10:12]
+        self.assertIsNot(l4_proto, 0)
 
     # ip_daddr = "1.1.1.1"
     def test_encode_ipv4_l4_proto_public_ip(self):
         # Checksum is 10th and 11th bytes
-        ip_saddr = self.test_encode_class_instance.encode_ipv4_header()[16:20]
+        ip_saddr = self.test_encode_class_instance.ipv4_packet[16:20]
         self.assertEqual(ip_saddr, socket.inet_aton("1.1.1.1"))
 
     # UDP Tests here
     def test_decode_udp(self):
-        udp_hdr = self.test_encode_class_instance.encode_ipv4_udp_packet()
+        udp_hdr = self.test_encode_class_instance.udp_packet
         self.assertIsInstance(udp_hdr, bytes)
 
     # udp_src_port = 35000
     def test_encode_udp_src(self):
         # src is 1st word
-        udp_src_port = self.test_encode_class_instance.encode_ipv4_udp_packet()[0:2]
+        udp_src_port = self.test_encode_class_instance.udp_packet[0:2]
         self.assertEqual(udp_src_port, struct.pack("!H", 35000))
 
     # udp_dst_port = 53
     def test_encode_udp_dst(self):
         # dst is 2nd word
-        udp_dst_port = self.test_encode_class_instance.encode_ipv4_udp_packet()[2:4]
+        udp_dst_port = self.test_encode_class_instance.udp_packet[2:4]
         self.assertEqual(udp_dst_port, struct.pack("!H", 53))
 
     # UDP Packet Length: 18, computed.
     def test_encode_udp_len(self):
         # Len is 3rd word
-        udp_len = self.test_encode_class_instance.encode_ipv4_udp_packet()[4:6]
+        udp_len = self.test_encode_class_instance.udp_packet[4:6]
         self.assertEqual(udp_len, struct.pack("!H", 18))
 
 

--- a/traceflow/__main__.py
+++ b/traceflow/__main__.py
@@ -71,7 +71,7 @@ def main():
             )
             # TODO: Maybe refactor to hide these behind a single function, to be v4/v6 agnostic
             # Combine the IPv4 and UDP headers here
-            probe = i.encode_ipv4_header() + i.encode_ipv4_udp_packet()
+            probe = i.ipv4_packet + i.udp_packet
 
             s = traceflow.socket_handler(ip_daddr)
             _ = s.send_ipv4(probe)

--- a/traceflow/packet.py
+++ b/traceflow/packet.py
@@ -195,9 +195,18 @@ class packet_decode:
         # Decode the first 20 bytes, rest will most likely be payload (We'll re-base with ip_ihl later on)
         logging.debug("Decoding IPv4 Header")
         ip_header = header[0:20]
-        ip_ihl_ver, ip_tos, ip_tot_len, ip_id, ip_frag_off, ttl, l4_proto, ip_check, ip_saddr, ip_daddr = struct.unpack(
-            "!BBHHHBBH4s4s", ip_header
-        )
+        (
+            ip_ihl_ver,
+            ip_tos,
+            ip_tot_len,
+            ip_id,
+            ip_frag_off,
+            ttl,
+            l4_proto,
+            ip_check,
+            ip_saddr,
+            ip_daddr,
+        ) = struct.unpack("!BBHHHBBH4s4s", ip_header)
         # since we cannot read nibbles easy, we need to take the first byte and take the high/low nibble out
         ip_ver = ip_ihl_ver >> 4
         ip_ihl = ip_ihl_ver & 0x0F  # 0x0F == 15

--- a/traceflow/packet.py
+++ b/traceflow/packet.py
@@ -3,6 +3,7 @@ import struct
 import logging
 import random
 import traceflow
+import time
 
 
 class packet_encode:
@@ -37,13 +38,13 @@ class packet_encode:
 
         if self.ip_ver == 4:
             # Do inet4 packet handling here
-            ## Values which the kernel will set are here
-            # TODO: BSD wont auto-set total length for us. We need a better way of doing this.
-            # Short term work around, set to min. ip header length (20) and min. UDP header length (8) + payload (10)
-            self.ip_tot_len = 38  # Kernel will set this value on linux if 0.
-            self.ip_check = 0  # Kernel should set this value
+            # Values which we need to re-write later on will be set to 0 here.
+            self.ip_tot_len = 0
+            self.ip_check = 0
+            self.ip_ihl = 0
 
             # Values we need to set now should be here
+            # Lets get the egress IP for this packet
             self.ip_saddr = socket.inet_aton(
                 socket.gethostbyname(
                     traceflow.socket_handler.get_egress_ip(self.ip_daddr)
@@ -61,26 +62,23 @@ class packet_encode:
             self.ip_id = (
                 self.ip_id if self.ip_id is not None else random.randint(0, 65535)
             )
-            ## TODO: Min header length is 20 bits, which is 5 * 8 (And an int is 8 bits wide). Should actually re-write this dynamically to set correct header size
-            self.ip_ihl = 5
             logging.debug(
                 f"Sending with ID {self.ip_id}, TTL {self.ttl} to {self.ip_daddr}"
             )
+            # Assemble the packet with ip_tot_len set to 0, then we will re-calculate it.
+            self.ipv4_packet = self._encode_ipv4_header()
+            # IHL is in "number of 32 bit words", which means we need to get length in bytes, then divide by 4 (Then cast back to int as we cannot use floating points)
+            self.ip_ihl = int(len(self.ipv4_packet) / 4)
+            self.udp_packet = self._encode_ipv4_udp_packet()
+            self.ip_tot_len = len(self.ipv4_packet + self.udp_packet)
+            self.ipv4_packet = self._encode_ipv4_header()
+            # TODO, also build the TCP packet here.
 
         if self.ip_ver == 6:
             # TODO: All of the IPv6 things
             pass
-        if self.l4_proto == socket.getprotobyname("udp"):
-            # Do UDP Stuff here
-            pass
-        if self.l4_proto == socket.getprotobyname("tcp"):
-            # Do TCP stuff here
-            pass
 
-    def get_ipid(self) -> int:
-        return self.ip_id
-
-    def encode_ipv4_header(self) -> bytes:
+    def _encode_ipv4_header(self) -> bytes:
         """
         encode_ipv4_header uses all fields passed in __init__ to contruct a valid IPv4 Header
 
@@ -108,10 +106,9 @@ class packet_encode:
             self.ip_saddr,
             self.ip_daddr,
         )
-        self.ip_packet = ip_header
         return ip_header
 
-    def encode_ipv4_udp_packet(self: object) -> bytes:
+    def _encode_ipv4_udp_packet(self: object) -> bytes:
         """
         encode_ipv4_udp_packet encodes a valid (IPv4) UDP packet. The IPv4 limitation is due to IPv4 requiring a pseudo header
         where as IPv6 no longer requires src/dst IP address to be used as input to the checksum function.
@@ -121,11 +118,9 @@ class packet_encode:
         """
         # Since we cannot determine the ip.id of the packet we send via socket.SOCK_DGRAM, we need to use raw sockets
         # To build a packet manually. This is the only way that I can see where we will know the ip.id in advance
-        # Taken inspiration from  https://github.com/houluy/UDP/blob/master/udp.py
-        # Generate some data, encode to bytes array, snag the length. Ensure data is even length, otherwise we have to add padding byte
-        # TODO: Encode timestamp here for future analysis
         logging.debug("Encoding UDP Packet now")
-        self.data = "0123456789".encode()
+        # put the current timestamp into the UDP payload.
+        self.data = str(int(time.time())).encode()
         # UDP is a bit stupid, and takes a lower layer info as part of it's checksum. Specifically src/dst IP addr.
         # This is called the pseudo header
         pseudo_header = struct.pack(


### PR DESCRIPTION
- Moving packet generation into private classes
- Changed access to packet from function to property
- Fixed IP Header Length calculation
- Fixed IP Total Length calculation
- Added unit timestamp into the UDP packet
- Fixed unittests to reflect new access methods

Signed-off-by: rucarrol <ruairi.carroll@gmail.com>